### PR TITLE
Update r0idamcp.py

### DIFF
--- a/r0idamcp.py
+++ b/r0idamcp.py
@@ -203,6 +203,7 @@ def create_demangled_to_ea_map():
             idc.get_name(ea, 0), idaapi.MNG_NODEFINIT)
         if demangled:
             DEMANGLED_TO_EA[demangled] = ea
+
 def parse_address(address: str) -> int:
     try:
         return int(address, 0)
@@ -211,6 +212,50 @@ def parse_address(address: str) -> int:
             if ch not in "0123456789abcdefABCDEF":
                 raise IDAError(f"Failed to parse address: {address}")
         raise IDAError(f"Failed to parse address (missing 0x prefix): {address}")
+
+def _resolve_function_ea(function_address_str: str, function_name: str, operation_description: str) -> int:
+    """
+    Resolves an address from either a string address or a function name.
+    One of function_address_str or function_name must be non-empty.
+    This EA can then be used with idaapi.get_func() to get the function context.
+    """
+    if not function_address_str and not function_name:
+        raise IDAError(f"For {operation_description}, either function_address or function_name must be provided.")
+
+    resolved_ea = idaapi.BADADDR
+
+    # Prioritize address if provided and valid
+    if function_address_str:
+        try:
+            resolved_ea = parse_address(function_address_str)
+        except IDAError as e:
+            # If address parsing fails but a name is also provided, we can try the name.
+            # If no name is provided, this is a fatal error for the address.
+            if not function_name:
+                raise IDAError(f"Invalid function_address '{function_address_str}' for {operation_description} and no function_name provided: {e}")
+            # resolved_ea remains BADADDR, name lookup will be attempted next
+            pass 
+
+    # If address was not provided, or was invalid (and name is available), try to use the name
+    if resolved_ea == idaapi.BADADDR and function_name:
+        resolved_ea = idaapi.get_name_ea(idaapi.BADADDR, function_name)
+        if resolved_ea == idaapi.BADADDR:
+            # Try demangled name
+            if not DEMANGLED_TO_EA: # Ensure map is populated if empty
+                create_demangled_to_ea_map()
+            if function_name in DEMANGLED_TO_EA:
+                resolved_ea = DEMANGLED_TO_EA[function_name]
+
+    # Final check if an EA was resolved
+    if resolved_ea == idaapi.BADADDR:
+        error_message_parts = [f"For {operation_description}, failed to resolve address. Input was:"]
+        if function_address_str:
+            error_message_parts.append(f"  - function_address: '{function_address_str}'")
+        if function_name:
+            error_message_parts.append(f"  - function_name: '{function_name}'")
+        raise IDAError("\n".join(error_message_parts))
+            
+    return resolved_ea
 
 @idaread
 def get_function_by_name_real(name: Annotated[str, "Name of the function to get"]) -> Function:
@@ -251,7 +296,7 @@ class ConvertedNumber(TypedDict):
 
 def convert_number_real(
     text: Annotated[str, "Textual representation of the number to convert"],
-    size: Annotated[Optional[int], "Size of the variable in bytes"],
+    size: Annotated[int, "Size of the variable in bytes (mandatory)"],
 ) -> ConvertedNumber:
     """Convert a number (decimal, hexadecimal) to different representations"""
     try:
@@ -259,36 +304,30 @@ def convert_number_real(
     except ValueError:
         raise IDAError(f"Invalid number: {text}")
 
-    # Estimate the size of the number
-    if not size:
-        size = 0
-        n = abs(value)
-        while n:
-            size += 1
-            n >>= 1
-        size += 7
-        size //= 8
+    # Size is now mandatory，因为在部分支持MCP的客户端中存在不允许省略可选参数的情况.
+    if not isinstance(size, int) or size <= 0:
+        raise IDAError(f"Invalid size: {size}. Must be a positive integer greater than 0.")
 
     # Convert the number to bytes
     try:
-        bytes = value.to_bytes(size, "little", signed=True)
+        bytes_val = value.to_bytes(size, "little", signed=True) # Renamed 'bytes' to 'bytes_val' to avoid conflict with built-in
     except OverflowError:
         raise IDAError(f"Number {text} is too big for {size} bytes")
 
     # Convert the bytes to ASCII
-    ascii = ""
-    for byte in bytes.rstrip(b"\x00"):
-        if byte >= 32 and byte <= 126:
-            ascii += chr(byte)
+    ascii_str = "" # Renamed 'ascii' to 'ascii_str'
+    for byte_char in bytes_val.rstrip(b"\x00"):
+        if byte_char >= 32 and byte_char <= 126:
+            ascii_str += chr(byte_char)
         else:
-            ascii = None
+            ascii_str = None
             break
 
     return {
         "decimal": str(value),
         "hexadecimal": hex(value),
-        "bytes": bytes.hex(" "),
-        "ascii": ascii,
+        "bytes": bytes_val.hex(" "),
+        "ascii": ascii_str,
         "binary": bin(value)
     }
 
@@ -348,31 +387,34 @@ def list_strings_real(
     strings = get_strings()
     return paginate(strings, offset, count)
 @idaread
-def search_strings_real(
-        pattern_str: Annotated[str, "The regular expression to match((The generated regular expression includes case by default))"],
+def search_strings_regex_real(
+        pattern_str: Annotated[str, "The regular expression to match (case-insensitive)"],
         offset: Annotated[int, "Offset to start listing from (start at 0)"],
         count: Annotated[int, "Number of strings to list (100 is a good default, 0 means remainder)"],
 ) -> Page[String]:
-    """Search for strings that satisfy a regular expression"""
+    """Search for strings that satisfy a regular expression."""
     strings = get_strings()
     try:
-        pattern = re.compile(pattern_str)
-    except Exception as e:
-        raise ValueError(f"Regular expression syntax error, reason is {e}")
+        # 如果需要不区分大小写，应使用 re.IGNORECASE 标志)
+        pattern = re.compile(pattern_str, re.IGNORECASE)
+    except re.error as e:
+        raise IDAError(f"Invalid regular expression syntax: {e}")
     try:
         matched_strings = [s for s in strings if s["string"] and re.search(pattern, s["string"])]
     except Exception as e:
-        raise ValueError(f"The regular match failed, reason is {e}")
+        raise IDAError(f"Regular expression matching failed: {e}")
     return paginate(matched_strings, offset, count)
+
 @idaread
-def search_strings_real(
+def search_strings_substring_real(
     pattern: Annotated[str, "Substring to search for in strings"],
     offset: Annotated[int, "Offset to start listing from (start at 0)"],
     count: Annotated[int, "Number of strings to list (100 is a good default, 0 means remainder)"],
 ) -> Page[String]:
-    """Search for strings containing the given pattern (case-insensitive)"""
+    """Search for strings containing the given pattern (case-insensitive)."""
     strings = get_strings()
-    matched_strings = [s for s in strings if pattern.lower() in s["string"].lower()]
+    # 执行不区分大小写的子字符串搜索
+    matched_strings = [s for s in strings if s["string"] and pattern.lower() in s["string"].lower()]
     return paginate(matched_strings, offset, count)
 
 def decompile_checked(address: int) -> ida_hexrays.cfunc_t:
@@ -388,35 +430,65 @@ def decompile_checked(address: int) -> ida_hexrays.cfunc_t:
             message += f" (address: {hex(error.errea)})"
         raise IDAError(message)
     return cfunc
+
 @idaread
 def decompile_function_real(
-    address: Annotated[str, "Address of the function to decompile"]
+    address: Annotated[str, "Address of the function to decompile. Can be empty if function_name is provided."],
+    function_name: Annotated[str, "Name of the function to decompile. Can be empty if address is provided."]
 ) -> str:
-    """Decompile a function at the given address"""
-    address = parse_address(address)
-    cfunc = decompile_checked(address)
+    """Decompile a function at the given address or by its name"""
+    
+    resolved_ea = _resolve_function_ea(address, function_name, "decompiling function")
+    
+    cfunc = decompile_checked(resolved_ea) # decompile_checked takes an integer EA
+    
     if is_window_active():
-        ida_hexrays.open_pseudocode(address, ida_hexrays.OPF_REUSE)
+        ida_hexrays.open_pseudocode(cfunc.entry_ea, ida_hexrays.OPF_REUSE) 
+        
     sv = cfunc.get_pseudocode()
     pseudocode = ""
+    func_object_for_bounds = idaapi.get_func(cfunc.entry_ea) # For address plausibility checks
+
     for i, sl in enumerate(sv):
         sl: ida_kernwin.simpleline_t
-        item = ida_hexrays.ctree_item_t()
-        addr = None if i > 0 else cfunc.entry_ea
+        item = ida_hexrays.ctree_item_t() # Must be created for each call to get_line_item
+        
+        current_line_addr = idaapi.BADADDR # Default for the line
+
+        # Attempt to get address from ctree_item associated with the line
         if cfunc.get_line_item(sl.line, 0, False, None, item, None):
-            ds = item.dstr().split(": ")
-            if len(ds) == 2:
-                try:
-                    addr = int(ds[0], 16)
-                except ValueError:
-                    pass
-        line = ida_lines.tag_remove(sl.line)
+            # Primary source: item.it.ea
+            if item.it and item.it.ea != idaapi.BADADDR:
+                current_line_addr = item.it.ea
+            else: 
+                # Fallback: try parsing item.dstr() if item.it.ea is not valid
+                # item.dstr() is available on ctree_item_t
+                ds = item.dstr().split(": ")
+                if len(ds) == 2:
+                    try:
+                        parsed_addr_from_dstr = int(ds[0], 16)
+                        # Plausibility check: address should be within the function's bounds
+                        if func_object_for_bounds and \
+                           func_object_for_bounds.start_ea <= parsed_addr_from_dstr < func_object_for_bounds.end_ea:
+                            current_line_addr = parsed_addr_from_dstr
+                    except ValueError:
+                        pass # Not a hex address prefix in dstr
+
+        # Special handling for the very first line:
+        # If decompilation was for the function's entry point, and no more specific
+        # address was found for the first line itself, use the function's entry_ea.
+        if i == 0 and resolved_ea == cfunc.entry_ea and current_line_addr == idaapi.BADADDR:
+            current_line_addr = cfunc.entry_ea
+        
+        line_text = ida_lines.tag_remove(sl.line)
         if len(pseudocode) > 0:
             pseudocode += "\n"
-        if not addr:
-            pseudocode += f"/* line: {i} */ {line}"
+        
+        if current_line_addr != idaapi.BADADDR:
+            pseudocode += f"/* line: {i}, address: {hex(current_line_addr)} */ {line_text}"
         else:
-            pseudocode += f"/* line: {i}, address: {hex(addr)} */ {line}"
+            pseudocode += f"/* line: {i} */ {line_text}"
+            
     return pseudocode
 
 @idaread
@@ -583,43 +655,48 @@ def refresh_decompiler_ctext(function_address: int):
         cfunc.refresh_func_ctext()
 @idawrite
 def rename_local_variable_real(
-    function_address: Annotated[str, "Address of the function containing the variable"],
+    function_address: Annotated[str, "Address of the function containing the variable. Can be empty if function_name is provided."],
+    function_name: Annotated[str, "Name of the function containing the variable. Can be empty if function_address is provided."],
     old_name: Annotated[str, "Current name of the variable"],
     new_name: Annotated[str, "New name for the variable (empty for a default name)"]
 ) -> str:
-    """Rename a local variable in a function with name conflict checking
+    """Rename a local variable in a function with name conflict checking"""
     
-    Returns:
-        str: Success message if successful, error message if failed or name conflict exists
-    """
-    func = idaapi.get_func(parse_address(function_address))
+    resolved_ea = _resolve_function_ea(function_address, function_name, "renaming local variable")
+    func = idaapi.get_func(resolved_ea)
     if not func:
-        return f"Error: No function found at address {function_address}"
+        input_spec = f"address '{function_address}'" if function_address else ""
+        if function_name:
+            if input_spec: input_spec += " or "
+            input_spec += f"name '{function_name}'"
+        return f"Error: No function found for {input_spec} (resolved to {hex(resolved_ea)})"
     
+    func_ea = func.start_ea # Use the actual start EA of the function
+
     # Check if new_name is empty (will use default name)
     if not new_name:
-        if not ida_hexrays.rename_lvar(func.start_ea, old_name, new_name):
-            return f"Error: Failed to rename local variable {old_name} in function {hex(func.start_ea)}"
-        refresh_decompiler_ctext(func.start_ea)
-        return f"Success: Local variable '{old_name}' renamed to default name in function {hex(func.start_ea)}"
+        if not ida_hexrays.rename_lvar(func_ea, old_name, ""): # Pass empty string for new_name
+            return f"Error: Failed to rename local variable '{old_name}' to default name in function {hex(func_ea)}"
+        refresh_decompiler_ctext(func_ea)
+        return f"Success: Local variable '{old_name}' renamed to default name in function {hex(func_ea)}"
     
     # Get decompilation of the function
-    cfunc = ida_hexrays.decompile(func.start_ea)
+    cfunc = ida_hexrays.decompile(func_ea)
     if not cfunc:
-        return f"Error: Failed to decompile function at {hex(func.start_ea)}"
+        return f"Error: Failed to decompile function at {hex(func_ea)}"
     
     # Check for name conflicts
     lvars = cfunc.get_lvars()
     for lvar in lvars:
         if lvar.name == new_name and lvar.name != old_name:
-            return f"Error: Variable name '{new_name}' already exists in function {hex(func.start_ea)}"
+            return f"Error: Variable name '{new_name}' already exists in function {hex(func_ea)}"
     
     # Perform the rename
-    if not ida_hexrays.rename_lvar(func.start_ea, old_name, new_name):
-        return f"Error: Failed to rename local variable {old_name} in function {hex(func.start_ea)}"
+    if not ida_hexrays.rename_lvar(func_ea, old_name, new_name):
+        return f"Error: Failed to rename local variable '{old_name}' to '{new_name}' in function {hex(func_ea)}"
     
-    refresh_decompiler_ctext(func.start_ea)
-    return f"Success: Local variable '{old_name}' renamed to '{new_name}' in function {hex(func.start_ea)}"
+    refresh_decompiler_ctext(func_ea)
+    return f"Success: Local variable '{old_name}' renamed to '{new_name}' in function {hex(func_ea)}"
 
 class my_modifier_t(ida_hexrays.user_lvar_modifier_t):
     def __init__(self, var_name: str, new_type: ida_typeinf.tinfo_t):
@@ -637,40 +714,58 @@ class my_modifier_t(ida_hexrays.user_lvar_modifier_t):
 
 @idawrite
 def set_local_variable_type_real(
-    function_address: Annotated[str, "Address of the function containing the variable"],
+    function_address: Annotated[str, "Address of the function containing the variable. Can be empty if function_name is provided."],
+    function_name: Annotated[str, "Name of the function containing the variable. Can be empty if function_address is provided."],
     variable_name: Annotated[str, "Name of the variable"],
     new_type: Annotated[str, "New type for the variable"]
 ) -> str:
-    """Set a local variable's type
+    """Set a local variable's type"""
     
-    Returns:
-        str: Success message with function address, variable name and new type
-    """
+    resolved_ea = _resolve_function_ea(function_address, function_name, "setting local variable type")
+    func = idaapi.get_func(resolved_ea)
+    if not func:
+        input_spec = f"address '{function_address}'" if function_address else ""
+        if function_name:
+            if input_spec: input_spec += " or "
+            input_spec += f"name '{function_name}'"
+        raise IDAError(f"No function found for {input_spec} (resolved to {hex(resolved_ea)})")
+
+    func_ea = func.start_ea # Use the actual start EA of the function
+
     # Parse the new type
     try:
-        # Some versions of IDA don't support this constructor
-        new_tif = ida_typeinf.tinfo_t(new_type, None, ida_typeinf.PT_SIL)
-    except Exception:
-        try:
-            new_tif = ida_typeinf.tinfo_t()
-            # parse_decl requires semicolon for the type
-            ida_typeinf.parse_decl(new_tif, None, new_type+";", ida_typeinf.PT_SIL)
-        except Exception:
-            raise IDAError(f"Failed to parse type: {new_type}")    
-    # Get the function
-    func = idaapi.get_func(parse_address(function_address))
-    if not func:
-        raise IDAError(f"No function found at address {function_address}")
-    # Rename (this is needed to find the variable)
-    if not ida_hexrays.rename_lvar(func.start_ea, variable_name, variable_name):
-        raise IDAError(f"Failed to find local variable: {variable_name}")    
+        new_tif = ida_typeinf.tinfo_t()
+        # parse_decl requires semicolon for the type
+        if ida_typeinf.parse_decl(new_tif, None, new_type+";", ida_typeinf.PT_SIL) is None:
+             # Fallback for older IDA versions or simpler types if parse_decl fails subtly
+            try:
+                new_tif = ida_typeinf.tinfo_t(new_type, None, ida_typeinf.PT_SIL)
+                if not new_tif.is_valid(): # Check if tinfo_t constructor worked
+                    raise IDAError(f"Failed to parse type (constructor): {new_type}")
+            except Exception as e_constr:
+                 raise IDAError(f"Failed to parse type with parse_decl and constructor: {new_type}. Details: {e_constr}")
+    except Exception as e_parse:
+        raise IDAError(f"Failed to parse type: {new_type}. Details: {e_parse}")    
+    
+    # Rename (this is needed to find the variable by ensuring it's in user lvars)
+    # Using the same name effectively "touches" the variable for Hex-Rays.
+    if not ida_hexrays.rename_lvar(func_ea, variable_name, variable_name):
+        # This might fail if the variable doesn't exist or isn't recognized by Hex-Rays yet.
+        # Attempting to decompile first might help Hex-Rays recognize it.
+        cfunc = ida_hexrays.decompile(func_ea)
+        if not cfunc:
+            raise IDAError(f"Failed to decompile function at {hex(func_ea)} to find local variable: {variable_name}")
+        if not ida_hexrays.rename_lvar(func_ea, variable_name, variable_name):
+             raise IDAError(f"Failed to find or prime local variable for type change: {variable_name} in function {hex(func_ea)}")
+    
     # Apply the type change
     modifier = my_modifier_t(variable_name, new_tif)
-    if not ida_hexrays.modify_user_lvars(func.start_ea, modifier):
-        raise IDAError(f"Failed to modify local variable: {variable_name}")    
-    refresh_decompiler_ctext(func.start_ea)    
+    if not ida_hexrays.modify_user_lvars(func_ea, modifier):
+        raise IDAError(f"Failed to modify local variable type: {variable_name} in function {hex(func_ea)}")    
+    
+    refresh_decompiler_ctext(func_ea)    
     return (f"Successfully changed type of variable '{variable_name}' "
-            f"in function at {hex(func.start_ea)} "
+            f"in function at {hex(func_ea)} "
             f"to '{new_type}'")
 
 @idawrite
@@ -699,48 +794,116 @@ def set_global_variable_type_real(
     return (f"Successfully changed type of variable '{variable_name}' "
             f"in function at {hex(ea)} "
             f"to '{new_type}'")
+
 @idawrite
 def rename_function_real(
-    function_address: Annotated[str, "Address of the function to rename"],
+    function_address: Annotated[str, "Address of the function to rename. Can be empty if function_name is provided."],
+    function_name: Annotated[str, "Name of the function to rename. Can be empty if function_address is provided."],
     new_name: Annotated[str, "New name for the function (empty for a default name)"]
 ) -> str:
-    """Rename a function
+    """Rename a function with name conflict checking."""
     
-    Returns:
-        str: Success message with the old and new function names
-    """
-    func = idaapi.get_func(parse_address(function_address))
+    resolved_ea = _resolve_function_ea(function_address, function_name, "renaming function")
+    func = idaapi.get_func(resolved_ea)
     if not func:
-        raise IDAError(f"No function found at address {function_address}")
+        input_spec = f"address '{function_address}'" if function_address else ""
+        if function_name:
+            if input_spec: input_spec += " or "
+            input_spec += f"name '{function_name}'"
+        raise IDAError(f"No function found for {input_spec} (resolved to {hex(resolved_ea)}).")
     
-    old_name = idaapi.get_name(func.start_ea)
-    if not idaapi.set_name(func.start_ea, new_name):
-        raise IDAError(f"Failed to rename function {hex(func.start_ea)} to {new_name}")
+    current_func_ea = func.start_ea # Use the actual start EA of the function
+    old_name = idaapi.get_name(current_func_ea)
+
+    if new_name and new_name != old_name:
+        existing_ea = idaapi.get_name_ea(idaapi.BADADDR, new_name)
+        
+        if existing_ea != idaapi.BADADDR and existing_ea != current_func_ea:
+            conflicting_item_type = "a global symbol"
+            conflicting_item_name = idaapi.get_name(existing_ea) 
+            if idaapi.get_func(existing_ea):
+                conflicting_item_type = f"function '{conflicting_item_name}'"
+            
+            return (f"Error: Name '{new_name}' is already used by {conflicting_item_type} "
+                    f"at {hex(existing_ea)}.")
+
+    if not idaapi.set_name(current_func_ea, new_name if new_name else "", idaapi.SN_CHECK): # SN_CHECK for safety, though set_name implies it
+        # If new_name is empty, IDA assigns a default. set_name should handle this.
+        # The SN_CHECK flag here is more about validating the name's characters/format if new_name is not empty.
+        # idaapi.set_name returns 0 on failure, 1 on success.
+        # If new_name is empty, set_name will attempt to give it a default name (e.g. sub_XXXX)
+        if not idaapi.set_name(current_func_ea, new_name if new_name else ""):
+             raise IDAError(f"Failed to rename function {hex(current_func_ea)} from '{old_name}' to '{new_name or 'default name'}'. "
+                       "This could be due to invalid characters in the new name or other IDA restrictions.")
     
-    refresh_decompiler_ctext(func.start_ea)
+    refresh_decompiler_ctext(current_func_ea)
     
-    # Get the actual new name (in case an empty string was provided and IDA chose a default)
-    actual_new_name = idaapi.get_name(func.start_ea)
+    actual_new_name = idaapi.get_name(current_func_ea)
+    return f"Successfully renamed function from '{old_name}' to '{actual_new_name}' at {hex(current_func_ea)}"
     
-    return f"Successfully renamed function from '{old_name}' to '{actual_new_name}' at {hex(func.start_ea)}"
 @idawrite
 def set_function_prototype_real(
-    function_address: Annotated[str, "Address of the function"],
+    function_address: Annotated[str, "Address of the function. Can be empty if function_name is provided."],
+    function_name: Annotated[str, "Name of the function. Can be empty if function_address is provided."],
     prototype: Annotated[str, "New function prototype"]
 ) -> str:
     """Set a function's prototype"""
-    func = idaapi.get_func(parse_address(function_address))
+    resolved_ea = _resolve_function_ea(function_address, function_name, "setting function prototype")
+    func = idaapi.get_func(resolved_ea)
     if not func:
-        raise IDAError(f"No function found at address {function_address}")
+        input_spec = f"address '{function_address}'" if function_address else ""
+        if function_name:
+            if input_spec: input_spec += " or "
+            input_spec += f"name '{function_name}'"
+        raise IDAError(f"No function found for {input_spec} (resolved to {hex(resolved_ea)})")
+
+    func_ea = func.start_ea # Use the actual start EA of the function
+
     try:
-        tif = ida_typeinf.tinfo_t(prototype, None, ida_typeinf.PT_SIL)
-        if not tif.is_func():
-            raise IDAError(f"Parsed declaration is not a function type")
-        if not ida_typeinf.apply_tinfo(func.start_ea, tif, ida_typeinf.PT_SIL):
-            raise IDAError(f"Failed to apply type")
-        refresh_decompiler_ctext(func.start_ea)
+        # Attempt to parse the declaration
+        tif = ida_typeinf.tinfo_t()
+        # PT_SIL: silent mode, PT_NDC: no decl, PT_TYP: type, PT_VAR: variable, PT_FUN: function
+        # We expect a function prototype, so PT_FUN might be relevant for parsing context,
+        # but apply_tinfo will verify if it's a function type.
+        # parse_decl is generally preferred for complex declarations.
+        # It expects a full declaration, often ending with a semicolon.
+        parsed_decl = prototype
+        if not parsed_decl.strip().endswith(';'):
+            # Heuristic: if it looks like a function prototype without a name, e.g. "int (int, char *)"
+            # we might need to give it a dummy name for parse_decl.
+            # However, apply_tinfo can often handle prototypes directly.
+            # For simplicity, let's try with apply_tinfo first, which uses parse_user_type_decl.
+            pass
+
+        # Using ida_typeinf.apply_tinfo directly as it internally calls parse_user_type_decl
+        # which is more robust for user-provided type strings.
+        # ida_typeinf.apply_tinfo will create a tinfo_t internally.
+        # We need to ensure the prototype string is correctly formatted for it.
+        # A common way is `ida_typeinf.parse_decl(tif, None, prototype + ";", ida_typeinf.PT_SIL)`
+        # and then `ida_typeinf.apply_tinfo(func_ea, tif, ida_typeinf.PT_SIL)`
+
+        temp_tif = ida_typeinf.tinfo_t()
+        # Add a semicolon if not present, as parse_decl often expects it.
+        prototype_to_parse = prototype.strip()
+        if not prototype_to_parse.endswith(";"):
+            prototype_to_parse += ";"
+        
+        if ida_typeinf.parse_decl(temp_tif, None, prototype_to_parse, ida_typeinf.PT_SIL) is None:
+            raise IDAError(f"Failed to parse prototype string: '{prototype}'. parse_decl returned None.")
+
+        if not temp_tif.is_func():
+            raise IDAError(f"Parsed declaration '{prototype}' is not a function type.")
+        
+        if not ida_typeinf.apply_tinfo(func_ea, temp_tif, ida_typeinf.PT_SIL):
+            raise IDAError(f"Failed to apply type information for prototype '{prototype}' to function at {hex(func_ea)}.")
+        
+        refresh_decompiler_ctext(func_ea)
+        return f"Successfully set prototype for function at {hex(func_ea)} to '{prototype}'"
+
     except Exception as e:
-        raise IDAError(f"Failed to parse prototype string: {prototype}")
+        # Catch any other exceptions during parsing or applying
+        raise IDAError(f"Failed to set function prototype '{prototype}' at {hex(func_ea) if func else resolved_ea}: {str(e)}")
+
 # NOTE: This is extremely hacky, but necessary to get errors out of IDA
 def parse_decls_ctypes(decls: str, hti_flags: int) -> tuple[int, str]:
     if sys.platform == "win32":
@@ -793,13 +956,11 @@ def declare_c_type_real(
 mcp = FastMCP(name="myServer")
 
 
-@mcp.tool()
-def greet(name: str) -> str:
-    return f"Hello roysue, {name}!"
-
+# 这些函数迟早要重排一遍顺序，使使用场景接近的函数接近，这样在提交给LLM的待续写文本中它们也会相近
+# --- START OF REVISED @mcp.tool FUNCTIONS ---
 @mcp.tool()
 def check_connection() -> str:
-    """Check if the IDA plugin is running"""
+    """Checks the connection status with the IDA Pro MCP server and retrieves the loaded module name."""
     try:
         metadata = get_metadata_real()
         return f"Successfully connected to IDA Pro (open file: {metadata['module']})"
@@ -811,140 +972,191 @@ def check_connection() -> str:
         return f"Failed to connect to IDA Pro! Did you run Edit -> Plugins -> MCP ({shortcut}) to start the server?"
 
 @mcp.tool()
-def get_metadata() -> Metadata:
-    """Get metadata about the current IDB"""
+def get_project_metadata() -> Metadata:
+    """Retrieves metadata about the currently IDA-Pro project."""
     return get_metadata_real()
+
 @mcp.tool()
-def get_function_by_name(name: Annotated[str, Field(description='Name of the function to get')]) -> Function:
-    """Get a function by its name"""
+def get_function_info_by_name(name: Annotated[str, Field(description='Mangled or demangled name of the target function.')]) -> Function:
+    """Retrieves details (address, name, size) for a function using its name (mangled or demangled)."""
     return get_function_by_name_real(name)
+
 @mcp.tool()
-def get_function_by_address(address: Annotated[str, Field(description='Address of the function to get')]) -> Function:
-    """Get a function by its address"""
+def get_function_info_by_address(address: Annotated[str, Field(description="A hexadecimal string start as '0x' (e.g., '0x14001000'), representation of the function's start address.")]) -> Function:
+    """Retrieves info (address, name, size) for a function using its starting address."""
     return get_function_by_address_real(address)
 
 @mcp.tool()
 def get_current_address() -> str:
-    """Get the address currently selected by the user"""
+    """Gets the address currently selected (under the cursor) in the IDA user interface."""
     return get_current_address_real()
 
 @mcp.tool()
 def get_current_function() -> Optional[Function]:
-    """Get the function currently selected by the user"""
+    """Gets details (address, name, size) of the function containing the currently selected in IDA window."""
     return get_current_function_real()
 
 @mcp.tool()
-def convert_number(text: Annotated[str, Field(description='Textual representation of the number to convert')], size: Annotated[Optional[int], Field(description='Size of the variable in bytes')]) -> ConvertedNumber:
-    """Convert a number (decimal, hexadecimal) to different representations"""
+def convert_number(
+    text: Annotated[str, Field(description='Number represented as a string (e.g., "100", "0x64"). Supports decimal and hexadecimal formats.')],
+    size: Annotated[int, Field(description='Mandatory size in bytes (positive integer) to assume for byte/ASCII conversion.')]
+) -> ConvertedNumber:
+    """Converts a number string (hex/dec) into various representations: decimal, hexadecimal, bytes (hex), potential ASCII, and binary."""
     return convert_number_real(text, size)
 
 @mcp.tool()
-def list_functions(offset: Annotated[int, Field(description='Offset to start listing from (start at 0)')], count: Annotated[int, Field(description='Number of functions to list (100 is a good default, 0 means remainder)')]) -> Page[Function]:
-    """List all functions in the database (paginated)"""
+def list_functions(
+    offset: Annotated[int, Field(description='Starting index for pagination (0-based).')],
+    count: Annotated[int, Field(description='Maximum number of function entries per page (0 retrieves all remaining functions from the offset).')]
+) -> Page[Function]:
+    """Lists functions defined in the analysis database, with support for pagination."""
     return list_functions_real(offset, count)
 
 @mcp.tool()
-def list_strings(offset: Annotated[int, Field(description='Offset to start listing from (start at 0)')], count: Annotated[int, Field(description='Number of strings to list (100 is a good default, 0 means remainder)')]) -> Page[String]:
-    """List all strings in the database (paginated)"""
+def list_strings(
+    offset: Annotated[int, Field(description='Starting index for pagination (0-based).')],
+    count: Annotated[int, Field(description='Similar to the list_functions method.')]
+) -> Page[String]:
+    """Lists string literals found in the analysis database, with support for pagination."""
     return list_strings_real(offset, count)
 
 @mcp.tool()
-def search_strings(pattern: Annotated[str, Field(description='Substring to search for in strings')], offset: Annotated[int, Field(description='Offset to start listing from (start at 0)')], count: Annotated[int, Field(description='Number of strings to list (100 is a good default, 0 means remainder)')]) -> Page[String]:
-    """Search for strings containing the given pattern (case-insensitive)"""
-    return search_strings_real(pattern, offset, count)
+def search_strings_regex(
+    pattern_str: Annotated[str, Field(description='Regular expression pattern to match against string literal content (case-insensitive).')],
+    offset: Annotated[int, Field(description='Starting index for pagination (0-based).')],
+    count: Annotated[int, Field(description='Maximum number of matching string literal entries per page (0 retrieves all remaining matches from the offset).')]
+) -> Page[String]:
+    """Searches for string literals matching a given regular expression (case-insensitive), returning results paginated."""
+    return search_strings_regex_real(pattern_str, offset, count)
 
 @mcp.tool()
-def decompile_function(address: Annotated[str, Field(description='Address of the function to decompile')]) -> str:
-    """Decompile a function at the given address"""
-    return decompile_function_real(address)
+def search_strings_substring(
+    pattern: Annotated[str, Field(description='Substring to search for within string literal content (case-insensitive).')],
+    offset: Annotated[int, Field(description='Similar to the search_strings_regex method.')],
+    count: Annotated[int, Field(description='Similar to the search_strings_regex method.')]
+) -> Page[String]:
+    """Searches for string literals containing a given substring (case-insensitive), returning results paginated."""
+    return search_strings_substring_real(pattern, offset, count)
 
 @mcp.tool()
-def disassemble_function(start_address: Annotated[str, Field(description='Address of the function to disassemble')]) -> str:
-    """Get assembly code (address: instruction; comment) for a function"""
+def decompile_function(
+    function_address: Annotated[str, Field(description="The function's start address, a hexadecimal string start as '0x' (e.g., '0x14001000'), if not empty string, function_name must be empty string(\"\").")],
+    function_name: Annotated[str, Field(description="The name of the function to decompile, if not empty string, function_address must be empty string(\"\").")]
+) -> str:
+    """Decompiles the function specified by function_address or function_name."""
+    return decompile_function_real(function_address, function_name)
+
+@mcp.tool()
+def disassemble_function(start_address: Annotated[str, Field(description="The function's start address, a hexadecimal string start as '0x'.")]) -> str:
+    """Retrieves the disassembly listing for a function, specified by its start address."""
     return disassemble_function_real(start_address)
 
 @mcp.tool()
-def get_xrefs_to(address: Annotated[str, Field(description='Address to get cross references to')]) -> list[Xref]:
-    """Get all cross references to the given address"""
+def get_xrefs_to(address: Annotated[str, Field(description="The target address, a hexadecimal string start as '0x'.")]) -> list[Xref]:
+    """Finds all code and data cross-references (Xrefs) that point *to* the given address."""
     return get_xrefs_to_real(address)
 
 @mcp.tool()
 def get_entry_points() -> list[Function]:
-    """Get all entry points in the database"""
+    """Lists all defined program entry point functions in the analysis database."""
     return get_entry_points_real()
 
 @mcp.tool()
-def set_comment(address: Annotated[str, Field(description='Address in the function to set the comment for')], comment: Annotated[str, Field(description='Comment text')])-> str:
-    """Set a comment for a given address in the function disassembly and pseudocode"""
+def set_comment(
+    address: Annotated[str, Field(description="Where the comment should be placed, a hexadecimal string start as '0x' (e.g., '0x14001000').")],
+    comment: Annotated[str, Field(description='The comment text.')]
+) -> str:
+    """Sets or updates a comment at a specific address. For line comments, the line address is presented in the decompiled code."""
     return set_comment_real(address, comment)
 
 @mcp.tool()
-def rename_local_variable(function_address: Annotated[str, Field(description='Address of the function containing the variable')], old_name: Annotated[str, Field(description='Current name of the variable')], new_name: Annotated[str, Field(description='New name for the variable (empty for a default name)')])-> str:
-    """Rename a local variable in a function"""
-    return rename_local_variable_real(function_address, old_name, new_name)
+def rename_local_variable(
+    function_address: Annotated[str, Field(description="A hexadecimal string start as '0x', if not empty string, function_name must be empty string(\"\").")],
+    function_name: Annotated[str, Field(description='The name of the function containing the local variable, if not empty string, function_address must be empty string("").')],
+    old_name: Annotated[str, Field(description='The current name of the local variable as seen in the decompilation.')],
+    new_name: Annotated[str, Field(description='The desired new name for the local variable. If empty, IDA assigns a default name.')]
+) -> str:
+    """Renames a local variable in a function. Identified by function_address or function_name."""
+    return rename_local_variable_real(function_address, function_name, old_name, new_name)
 
 @mcp.tool()
-def set_local_variable_type(function_address: Annotated[str, Field(description='Address of the function containing the variable')], variable_name: Annotated[str, Field(description='Name of the variable')], new_type: Annotated[str, Field(description='New type for the variable')])-> str:
-    """Set a local variable's type"""
-    return set_local_variable_type_real(function_address, variable_name, new_type)
+def set_local_variable_type(
+    function_address: Annotated[str, Field(description="A hexadecimal string start as'0x'.")],
+    function_name: Annotated[str, Field(description="The name of the function containing the local variable.")],
+    variable_name: Annotated[str, Field(description='The name of the local variable.')],
+    new_type: Annotated[str, Field(description='The new C-style data type declaration string (e.g., "int", "char *", "MyStruct *").')]
+) -> str:
+    """Sets the data type of a local variable in the function. Identified by function_address or function_name, if provid one, the other one must be empty string("")."""
+    return set_local_variable_type_real(function_address, function_name, variable_name, new_type)
 
 @mcp.tool()
-def rename_global_variable(old_name: Annotated[str, Field(description='Current name of the global variable')], new_name: Annotated[str, Field(description='New name for the global variable (empty for a default name)')]) -> str:
-    """Rename a global variable"""
+def rename_global_variable(
+    old_name: Annotated[str, Field(description='The current name of the global variable or function.')],
+    new_name: Annotated[str, Field(description='The desired new name.')]
+) -> str:
+    """Renames a global variable (data location) or function identified by its current name."""
     return rename_global_variable_real(old_name, new_name)
 
 @mcp.tool()
-def set_global_variable_type(variable_name: Annotated[str, Field(description='Name of the global variable')], new_type: Annotated[str, Field(description='New type for the variable')]) -> str:
-    """Set a global variable's type"""
+def set_global_variable_type(
+    variable_name: Annotated[str, Field(description='The name of the global variable whose type needs to be changed.')],
+    new_type: Annotated[str, Field(description='The new C-style data type declaration string (e.g., "int", "MyStruct *", "char[16]").')]
+) -> str:
+    """Sets the data type of a global variable identified by its name."""
     return set_global_variable_type_real(variable_name, new_type)
 
 @mcp.tool()
-def rename_function(function_address: Annotated[str, Field(description='Address of the function to rename')], new_name: Annotated[str, Field(description='New name for the function (empty for a default name)')])-> str:
-    """Rename a function"""
-    return rename_function_real(function_address, new_name)
+def rename_function(
+    function_address: Annotated[str, Field(description="A hexadecimal string start as'0x' (e.g., '0x14001000'), if not empty string, function_name must be empty string(\"\").")],
+    function_name: Annotated[str, Field(description="The name of the function to rename, if not empty string, function_address must be empty string(\"\")")],
+    new_name: Annotated[str, Field(description='The desired new name for the function. If empty, IDA assigns a default name.')]
+) -> str:
+    """Renames the function. Identified by function_address or function_name."""
+    return rename_function_real(function_address, function_name, new_name)
+    
+@mcp.tool()
+def set_function_prototype(
+    function_address: Annotated[str, Field(description="A hexadecimal string start as'0x'.")],
+    function_name: Annotated[str, Field(description="The name of the function whose prototype will be set.")],
+    prototype: Annotated[str, Field(description='The new C-style function prototype string (e.g., "int __cdecl my_func(int a, char *b)", "void setup(void)").')]
+) -> str:
+    """Sets the C-style function prototype for the function. Identified by function_address or function_name, if provid one, the other one must be empty string."""
+    return set_function_prototype_real(function_address, function_name, prototype)
 
 @mcp.tool()
-def set_function_prototype(function_address: Annotated[str, Field(description='Address of the function')], prototype: Annotated[str, Field(description='New function prototype')]) -> str:
-    """Set a function's prototype"""
-    return set_function_prototype_real(function_address, prototype)
-
-@mcp.tool()
-def declare_c_type(c_declaration: Annotated[str, Field(description='C declaration of the type. Examples include: typedef int foo_t; struct bar { int a; bool b; };')]):
-    """Create or update a local type from a C declaration"""
-    return declare_c_type_real(c_declaration)       
+def declare_c_type(
+    c_declaration: Annotated[str, Field(description='A C language declaration string defining a struct, union, enum, or typedef (e.g., "typedef int user_id_t;", "struct Point { int x; int y; };").')]
+):
+    """Declares or updates a local type (struct, union, enum, typedef) within IDA's type system using a C declaration string."""
+    return declare_c_type_real(c_declaration)
 
 @mcp.tool()
 def get_segments() -> List[Dict[str, Any]]:
-    """Get all segments information.
-    @return: List of segments (start, end, name, class, perm, bitness, align, comb, type, sel, flags)
-    """
+    """Retrieves information about all memory segments defined in the analysis database (e.g., .text, .data)."""
     return get_segments_real()
 
 @mcp.tool()
-def get_instruction_length(address: int) -> int:
-    """
-    Retrieves the length (in bytes) of the instruction at the specified address.
-    Args:
-        address: The address of the instruction.
-    Returns:
-        The length (in bytes) of the instruction.  Returns 0 if the instruction cannot be decoded.
-    """
-    return get_instruction_length_real(address)
+def get_machine_instruction_length(address: Annotated[str, Field(description="Address of the machine instruction (e.g., '0x14001000').")]) -> int:
+    """Gets the length (in bytes) of the machine instruction located at the given address."""
+    parsed_address = parse_address(address)
+    return get_instruction_length_real(parsed_address)
 
 @mcp.tool()
 @idaread
-def get_bytes(ea: int, size: int) -> List[int]:
-    """Get bytes at specified address.
-    Args:
-        ea: Effective address to read from
-        size: Number of bytes to read
-    """
+def get_bytes(
+    address: Annotated[str, Field(description="Address to start reading bytes from.")],
+    size: Annotated[int, Field(description="The number of bytes to read.")]
+) -> List[int]:
+    """Reads a sequence of byte values from the specified address. Returns a list of integers (0-255)."""
+    parsed_ea = parse_address(address)
     try:
-        result = [ida_bytes.get_byte(ea + i) for i in range(size)]
+        result = [ida_bytes.get_byte(parsed_ea + i) for i in range(size)]
         return result
     except Exception as e:
         print(f"Error in get_bytes: {str(e)}")
-        return {"error": str(e)}
+        raise IDAError(f"Failed to read bytes at {hex(parsed_ea)}: {str(e)}") from e
+
+# --- END OF REVISED @mcp.tool FUNCTIONS ---
 
 def startASYNC():
      asyncio.run(mcp.run_sse_async(host="0.0.0.0", port=26868, log_level="debug"))


### PR DESCRIPTION
修正了重复的search_strings函数，现在将提供两个独立的字符串匹配工具。
移除了greet工具，由于与check_connection工具的功能重合并额外占用上下文。
修改了convert_number工具的size参数为必填，因为有些支持MCP的客户端不允许使用可选参数。
为rename_function增加了类似rename_local_variable的逻辑，现在它们都会检查新名字是否与现有名称重复，并予以适当的错误反馈。
调整了rename_local_variable、set_local_variable_type、rename_function、set_function_prototype、decompile_function这五个工具的参数，现在它们接受函数名作为函数地址的替代，这在基于反编译代码的整理工作中减少了50%的工具调用次数。
调整了部分工具名和变量名，如get_instruction_length，“instruction”关键字可能误导LLM。
调整了大量工具描述和参数描述，这将导致更多的上下文被占用，但清晰的描述是必要的，这些提示词的调整将是长期工作。

Fixed duplicate search_strings functions, now provide two independent string matching tools.
Removed greet tool, because it overlaps with check_connection tool and takes up extra context.
Changed size parameter of convert_number tool to be required, because some clients supporting MCP do not allow optional parameters.
Added similar logic to rename_local_variable for rename_function, now they will check whether the new name is a duplicate of the existing name and give appropriate error feedback.
Adjusted the parameters of rename_local_variable, set_local_variable_type, rename_function, set_function_prototype, decompile_function tools, now they accept function name as a substitute for function address, which reduces the number of tool calls by 50% in decompiled code-based cleaning work.
Adjusted some tool names and variable names, such as get_instruction_length, the "instruction" keyword may mislead LLM.
A large number of tool descriptions and parameter descriptions have been adjusted, which will result in more context being occupied, but clear descriptions are necessary and the adjustment of these prompt words will be a long-term work.

![J G@5PFIP%X9)LYA%LQLQ~N](https://github.com/user-attachments/assets/084d25d5-e595-481f-8851-39f033b4db1e)

![I82Y@5 T_QTBYMK7KJK`WFV](https://github.com/user-attachments/assets/73e22247-029a-4891-a05a-90c8b5db5006)

![VE1C%U98%1 XP668MP Z2NO](https://github.com/user-attachments/assets/bf8164dd-8c9b-4d10-8bb8-827951d76a85)

![LRQIWJC5RXV`} (874Y6N65](https://github.com/user-attachments/assets/16b5954c-1dc5-4a18-b968-2300c990b5a0)

![FHN{(J0@RR~7`J(6HWA}X{U](https://github.com/user-attachments/assets/638703c8-5c68-4b4d-b70d-5da7878627d8)

![2Y3A I1P~EWW01NQLJH_6C5](https://github.com/user-attachments/assets/da1797ee-1d2a-4fa6-80bd-017c517dd806)

![_DAN}K%MACHIQSTSQEUANT7](https://github.com/user-attachments/assets/0cd275b0-1ecb-4c85-9f8e-c6d6cb40c2e7)

![$)178UL$E` ULKMK~)}VL{5](https://github.com/user-attachments/assets/90dd0b4f-e64e-49d6-9f34-fca57b43e9fc)
